### PR TITLE
Compile and warning fixes

### DIFF
--- a/include/mpp/endpoint.h
+++ b/include/mpp/endpoint.h
@@ -51,7 +51,7 @@ class endpoint {
 	const comm& 	m_comm;  // The MPI communicator this endpoing
 							 // belongs to
 
-	typedef int (*send_ptr)(void*,int,MPI_Datatype,int,int,MPI_Comm);
+	typedef int (*send_ptr)(void const*,int,MPI_Datatype,int,int,MPI_Comm);
 
 	// Make this class non-copyable
 	endpoint(const endpoint& other) = delete;

--- a/include/mpp/type_traits.h
+++ b/include/mpp/type_traits.h
@@ -162,7 +162,7 @@ struct mpi_type_traits<std::list<T>> {
 		std::vector<MPI_Datatype>::iterator type_it = types.begin();
 
 		MPI_Aint base_address;
-		MPI_Address(const_cast<T*>(&l.front()), &base_address);
+		MPI_Get_Address(const_cast<T*>(&l.front()), &base_address);
 
 		*(type_it++) = mpi_type_traits<T>::get_type( l.front() );
 		*(dim_it++) = static_cast<int>(mpi_type_traits<T>::get_size( l.front() ));
@@ -175,7 +175,7 @@ struct mpi_type_traits<std::list<T>> {
 						  type_it != types.end() &&
 						  dim_it != dimension.end() );
 
-				MPI_Address(const_cast<T*>(&curr), &*address_it);
+				MPI_Get_Address(const_cast<T*>(&curr), &*address_it);
 				*(address_it++) -= base_address;
 				*(type_it++) =  mpi_type_traits<T>::get_type( curr );
 				*(dim_it++) = static_cast<int>(mpi_type_traits<T>::get_size( curr ));

--- a/test/simple_sendrecv.cc
+++ b/test/simple_sendrecv.cc
@@ -5,7 +5,7 @@
 #include <cmath>
 #include <chrono>
 
-using namespace mpi;
+using namespace mpp;
 
 TEST(SendRecv, Scalar) {
 	if(comm::world.rank() == 0) {
@@ -91,7 +91,7 @@ TEST(SendRecv, Array) {
  	}
  
  	while ( p <= 10 ) {
- 		auto ep = (comm::world(mpi::any) >> p ).source();
+ 		auto ep = (comm::world(mpp::any) >> p ).source();
  		ep << p+1;
  		EXPECT_TRUE(comm::world.rank()==0?p%2!=0:p%2==0);
  	}
@@ -154,7 +154,7 @@ TEST(Performance, MpiScalar) {
 
 TEST(Performance, MppScalar) {
 
-	using mpi::comm;
+	using mpp::comm;
 	auto& world = comm::world;
 
 	auto bench = [&]() {

--- a/test/types.cc
+++ b/test/types.cc
@@ -3,7 +3,7 @@
 #include <mpp.h>
 #include <iostream>
 
-using namespace mpi;
+using namespace mpp;
 
 TEST(Type, Char) {
 	if(comm::world.rank() == 0) {


### PR DESCRIPTION
Recent OpenMPI versions generate warnings and compile errors with the aging codebase. The pull request fixes this by

1.) using mpp namespace instead of mpi also in the tests
2.) using a const void\* in the send functions <- this is the most serious change and should be reviewed
3.) using MPI_Get_Address instead of MPI_Address (deprecated, only for the warnings)
